### PR TITLE
Make sequencer run faster than DA

### DIFF
--- a/kubernetes/celestia-local/scripts/start-celestia-appd.sh
+++ b/kubernetes/celestia-local/scripts/start-celestia-appd.sh
@@ -3,8 +3,6 @@
 set -o errexit -o nounset
 
 sed -i'.bak' "s#\"tcp://127.0.0.1:26657\"#\"tcp://0.0.0.0:$celestia_app_host_port\"#g" $home_dir/config/config.toml
-sed -i'.bak' 's/timeout_commit = "25s"/timeout_commit = "1s"/g' $home_dir/config/config.toml
-sed -i'.bak' 's/timeout_propose = "10s"/timeout_propose = "1s"/g' $home_dir/config/config.toml
 
 # Start the celestia-app
 exec celestia-appd start --home "${home_dir}"

--- a/kubernetes/sequencer/deployment.yml
+++ b/kubernetes/sequencer/deployment.yml
@@ -64,6 +64,7 @@ spec:
           image: "ghcr.io/astriaorg/sequencer-relayer:0.0.6--sequencer-relayer"
           command: ["/usr/local/bin/astria-sequencer-relayer"]
           args:
+            - "--block-time=1000"
             - "--sequencer-endpoint=http://localhost:1318"
             - "--celestia-endpoint=http://celestia-service:26659"
             - "--validator-key-file=/root/.metro/config/priv_validator_key.json"

--- a/kubernetes/sequencer/scripts/start-metro.sh
+++ b/kubernetes/sequencer/scripts/start-metro.sh
@@ -2,5 +2,8 @@
 
 set -o errexit -o nounset
 
+sed -i'.bak' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $home_dir/config/config.toml
+sed -i'.bak' 's/timeout_propose = "10s"/timeout_propose = "1s"/g' $home_dir/config/config.toml
+
 # Start the celestia-app
 exec metro start --home "${home_dir}"


### PR DESCRIPTION
- Updates Celestia to be at 25s block times (or whatever default is)
- Updates Metro to be at 1s block times
- Updates sequencer-relayer to match Metro with 1 sec interval

Blocked by https://github.com/astriaorg/astria/issues/122