### PR TITLE
remove unused config value

### DIFF
--- a/kubernetes/geth/config-maps.yml
+++ b/kubernetes/geth/config-maps.yml
@@ -12,7 +12,6 @@ metadata:
   name: geth-env
   namespace: astria-dev-cluster
 data:
-  executor_local_account: "0xb0E31D878F49Ec0403A25944d6B1aE1bf05D17E1"
   home_dir: "/home/geth"
   executor_host_http_port: "8545"
   executor_host_grpc_port: "50051"


### PR DESCRIPTION
`executor_local_account` is no longer needed after moving `geth_genesis.json` to this repo