### PR TITLE
Fix websocket ingress

### DIFF
--- a/kubernetes/local-ingress.yml
+++ b/kubernetes/local-ingress.yml
@@ -3,6 +3,10 @@ kind: Ingress
 metadata:
   name: astria-dev-cluster-ingress
   namespace: astria-dev-cluster
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 spec:
   rules:
     - host: executor.astria.localdev.me
@@ -15,7 +19,10 @@ spec:
                 name: evm-service
                 port:
                   name: json-rpc-svc
-          - path: "/ws"
+    - host: ws-executor.astria.localdev.me
+      http:
+        paths:
+          - path: "/"
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
Websocket ingress wasn't working with nginx, this exposes the websocket port correctly as tested using `wscat`.

Docs on websockets w/ nginx: https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#websockets

Output from manual test:
```
❯ wscat -c ws://ws-executor.astria.localdev.me/

Connected (press CTRL+C to quit)
> {"jsonrpc":  "2.0", "id": 0, "method":  "eth_gasPrice"}
< {"jsonrpc":"2.0","id":0,"result":"0x63af7e95"}
```