### PR TITLE
Change name of duplicated just command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ just wait-for-ingress-controller
 just deploy-astria-local
 
 # Deploys a geth chain + faucet + ingress
-just deploy-geth
+just deploy-geth-local
 ```
 
 ### Configuring Funding of Geth

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ deploy-ingress-local:
 
 deploy-astria-local: deploy-namespace deploy-celestia-local deploy-sequencer
 
-deploy-geth: deploy-geth deploy-faucet deploy-ingress-local
+deploy-geth-local: deploy-geth deploy-faucet deploy-ingress-local
 
 wait-for-astria:
   kubectl wait -n astria-dev-cluster deployment geth --for=condition=Available=True --timeout=600s


### PR DESCRIPTION
We had two `deploy-geth`s that was causing just to error out