### PR TITLE
add wait-for-sequencer to deploy-all-local

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,10 +39,10 @@ deploy-astria-local: deploy-namespace deploy-celestia-local deploy-sequencer
 
 deploy-geth-local: deploy-geth deploy-faucet deploy-blockscout deploy-ingress-local
 
-deploy-all-local: create-control-plane deploy-ingress-controller wait-for-ingress-controller deploy-astria-local deploy-geth-local
+deploy-all-local: create-control-plane deploy-ingress-controller wait-for-ingress-controller deploy-astria-local deploy-geth-local wait-for-sequencer
 
-wait-for-astria:
-  kubectl wait -n astria-dev-cluster deployment geth --for=condition=Available=True --timeout=600s
+wait-for-sequencer:
+  kubectl wait -n astria-dev-cluster deployment sequencer --for=condition=Available=True --timeout=600s
 
 clean:
   kind delete cluster --name astria-dev-cluster


### PR DESCRIPTION
`wait-for-astria` was insufficient and also incorrectly named (it was actually waiting for geth)

This PR implements a `wait-for-sequencer` just command and adds it to `deploy-all-local`
