### PR TITLE
Fix ordering of deploy and wait commands in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,7 +39,10 @@ deploy-astria-local: deploy-namespace deploy-celestia-local deploy-sequencer
 
 deploy-geth-local: deploy-geth deploy-faucet deploy-blockscout deploy-ingress-local
 
-deploy-all-local: create-control-plane deploy-ingress-controller wait-for-ingress-controller deploy-astria-local deploy-geth-local wait-for-sequencer
+deploy-all-local: create-control-plane deploy-ingress-controller wait-for-ingress-controller deploy-astria-local wait-for-sequencer deploy-geth-local wait-for-geth
+
+wait-for-geth:
+  kubectl wait -n astria-dev-cluster deployment geth --for=condition=Available=True --timeout=600s
 
 wait-for-sequencer:
   kubectl wait -n astria-dev-cluster deployment sequencer --for=condition=Available=True --timeout=600s


### PR DESCRIPTION
Moves `wait-for-sequencer` to before `deploy-geth-local`, and also adds a `wait-for-geth` after `deploy-geth-local`.

See https://github.com/astriaorg/dev-cluster/pull/50#discussion_r1267618916

> at least right now gossipnet only works when sequencer is up before conductor, because conductor knows how to connect to sequencer as bootnode but conductor is non deterministic.