### PR TITLE
feat: dev rollup

### DIFF
--- a/charts/rollup/Chart.yaml
+++ b/charts/rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rollup/templates/configmap.yaml
+++ b/charts/rollup/templates/configmap.yaml
@@ -9,7 +9,8 @@ data:
   ASTRIA_CONDUCTOR_CELESTIA_NODE_URL: "{{ include "celestiaNode.service.adresses.rpc" (index .Subcharts "celestia-node") }}"
   TOKEN_SERVER_URL: "{{ include "celestiaNode.service.adresses.token" (index .Subcharts "celestia-node") }}"
   {{- else }}
-  ASTRIA_CONDUCTOR_CELESTIA_NODE_URL: "{{ .Values.config.celestiaNode.rpc }}"
+  ASTRIA_CONDUCTOR_CELESTIA_NODE_URL: "{{ .Values.config.celestia.rpc }}"
+  TOKEN_SERVER_URL: "{{ .Values.config.celestia.token }}"
   {{- end }}
   ASTRIA_CONDUCTOR_CHAIN_ID: "{{ .Values.config.rollup.chainId }}"
   ASTRIA_CONDUCTOR_EXECUTION_RPC_URL: "http://127.0.0.1:{{ .Values.ports.executionGRPC }}"

--- a/charts/rollup/values.yaml
+++ b/charts/rollup/values.yaml
@@ -64,6 +64,7 @@ config:
     # if config.rollup.executionLevel is NOT 'SoftOnly' AND celestia-node is not enabled
     # this must be set to access celestia network.
     rpc: ""
+    token: ""
 
 celestia-node:
   # Strongly recommend leaving enabled when not doing `SoftOnly` execution

--- a/justfile
+++ b/justfile
@@ -69,6 +69,16 @@ deploy-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAll
     {{ if sequencerStartBlock != '' { replace('--set config.sequencer.initialBlockHeight=#', '#', sequencerStartBlock) } else { '' } }} \
     {{rollupName}}chain-chart-deploy ./charts/rollup
 
+deploy-local-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAllocAddress=defaultGenesisAllocAddress privateKey=defaultPrivateKey sequencerStartBlock=defaultSequencerStartBlock:
+  helm install --debug \
+    {{ if rollupName          != '' { replace('--set config.rollup.name=# --set config.rollup.chainId=#chain --set celestia-node.config.labelPrefix=#', '#', rollupName) } else { '' } }} \
+    {{ if networkId           != '' { replace('--set config.rollup.networkId=#', '#', networkId) } else { '' } }} \
+    {{ if genesisAllocAddress != '' { replace('--set config.rollup.genesisAccounts[0].address=#', '#', genesisAllocAddress) } else { '' } }} \
+    {{ if privateKey          != '' { replace('--set config.faucet.privateKey=#', '#', privateKey) } else { '' } }} \
+    {{ if sequencerStartBlock != '' { replace('--set config.sequencer.initialBlockHeight=#', '#', sequencerStartBlock) } else { '' } }} \
+    -f values/rollup/dev.yaml \
+    {{rollupName}}chain-chart-deploy ./charts/rollup
+
 wait-for-rollup rollupName=defaultRollupName:
   kubectl wait -n astria-dev-cluster deployment {{rollupName}}-geth --for=condition=Available=True --timeout=600s
   kubectl wait -n astria-dev-cluster deployment {{rollupName}}-blockscout --for=condition=Available=True --timeout=600s

--- a/justfile
+++ b/justfile
@@ -25,7 +25,7 @@ load-image image:
   kind load docker-image {{image}} --name astria-dev-cluster
 
 deploy-chart chart:
-  helm install --debug --dry-run {{chart}}-chart ./charts/{{chart}} 
+  helm install --debug {{chart}}-chart ./charts/{{chart}} 
 
 delete-chart chart:
   helm uninstall {{chart}}-chart
@@ -69,7 +69,7 @@ deploy-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAll
     {{ if sequencerStartBlock != '' { replace('--set config.sequencer.initialBlockHeight=#', '#', sequencerStartBlock) } else { '' } }} \
     {{rollupName}}chain-chart-deploy ./charts/rollup
 
-deploy-local-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAllocAddress=defaultGenesisAllocAddress privateKey=defaultPrivateKey sequencerStartBlock=defaultSequencerStartBlock:
+deploy-dev-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAllocAddress=defaultGenesisAllocAddress privateKey=defaultPrivateKey sequencerStartBlock=defaultSequencerStartBlock:
   helm install --debug \
     {{ if rollupName          != '' { replace('--set config.rollup.name=# --set config.rollup.chainId=#chain --set celestia-node.config.labelPrefix=#', '#', rollupName) } else { '' } }} \
     {{ if networkId           != '' { replace('--set config.rollup.networkId=#', '#', networkId) } else { '' } }} \

--- a/values/rollup/dev.yaml
+++ b/values/rollup/dev.yaml
@@ -1,0 +1,7 @@
+config:
+  celestia:
+     rpc: "http://celestia-service.astria-dev-cluster.svc.cluster.local:26658"
+     token: "http://celestia-service.astria-dev-cluster.svc.cluster.local:5353"
+
+celestia-node:
+  enabled: false


### PR DESCRIPTION
Using rollups with local celestia network became more complicated with update to light clients, wasn't great for local development.

Added a configuration set that allows to reuse the bridge and a just command to run it. 