### PR TITLE
wip: chain id instead of rollup name

### DIFF
--- a/charts/celestia-node/templates/_helpers.tpl
+++ b/charts/celestia-node/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Define the base label
 */}}
 {{- define "celestiaNode.baseLabel" -}}
-{{- if .Values.config.labelPrefix }}{{ .Values.config.labelPrefix }}-{{- end }}{{ .Values.config.name }}-{{ .Values.config.type }}-{{ .Values.config.chainId }}
+{{- if .Values.config.labelPrefix }}{{ .Values.config.labelPrefix }}-{{- end }}{{ tpl .Values.config.labelTemplate . }}
 {{- end }}
 
 {{/*

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -7,6 +7,8 @@ global:
 
 config:
   name: celestia-node
+  labelPrefix: ''
+  labelTemplate: '{{ .Values.config.name }}-{{ .Values.config.type }}-{{ .Values.config.chainId }}'
   network: mocha-4
   chainId: mocha-4
   coreIp: "full.consensus.mocha-4.celestia-mocha.com"

--- a/charts/rollup/templates/configmap.yaml
+++ b/charts/rollup/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   ASTRIA_CONDUCTOR_CELESTIA_NODE_URL: "{{ .Values.config.celestia.rpc }}"
   TOKEN_SERVER_URL: "{{ .Values.config.celestia.token }}"
   {{- end }}
-  ASTRIA_CONDUCTOR_CHAIN_ID: "{{ .Values.config.rollup.chainId }}"
+  ASTRIA_CONDUCTOR_ROLLUP_NAME: "{{ .Values.config.rollup.name }}"
   ASTRIA_CONDUCTOR_EXECUTION_RPC_URL: "http://127.0.0.1:{{ .Values.ports.executionGRPC }}"
   ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL: "{{ .Values.config.rollup.executionCommitLevel }}"
   ASTRIA_CONDUCTOR_SEQUENCER_URL: "{{ .Values.config.sequencer.websocket }}"

--- a/charts/rollup/values.yaml
+++ b/charts/rollup/values.yaml
@@ -13,8 +13,6 @@ config:
   rollup:
     # Default name for the rollup chain
     name: astria
-    # Chain ID used for submission to shared sequencer, and generating DA namespace
-    chainId: astria
     # EVM network ID used by the chain
     networkId: 1337
     # Determines what will drive block execution, options are:
@@ -72,6 +70,7 @@ celestia-node:
   # By default the celestia node deploys on top of the Celestia testnet mocha network
   config:
     labelPrefix: astria
+    labelTemplate: cel-light
     type: light
     tokenAuthLevel: read
     # You can deploy on top of a custom celestia network, uncomment below and
@@ -87,8 +86,8 @@ celestia-node:
 images:
   # Core images for the rollup, developed for Astria
   geth: "ghcr.io/astriaorg/go-ethereum:0.4.1"
-  conductor: "ghcr.io/astriaorg/conductor:0.11.0--conductor"
-  composer: "ghcr.io/astriaorg/composer:0.3.0--composer"
+  conductor: "ghcr.io/astriaorg/conductor:pr-633"
+  composer: "ghcr.io/astriaorg/composer:pr-633"
 
   # Rollup faucet
   faucet: "ghcr.io/astriaorg/ria-faucet:0.0.1"


### PR DESCRIPTION
Using chain id instead of rollup name, additionally shortening the service name to create a rollup name limit. 