### PR TITLE
Allow generic rollup genesis alloc

### DIFF
--- a/charts/rollup/Chart.yaml
+++ b/charts/rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.8
+version: 0.7.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rollup/files/genesis/geth-genesis.json
+++ b/charts/rollup/files/genesis/geth-genesis.json
@@ -17,9 +17,9 @@
     "difficulty": "10000000",
     "gasLimit": "8000000",
     "alloc": {
-    {{- range $index, $value := .Values.config.rollup.genesisAccounts }}
+    {{- range $index, $value := .Values.config.rollup.genesisAlloc }}
         {{- if $index }},{{- end }}
-        "{{ $value.address }}": { "balance": "{{ $value.balance }}" }
+        "{{ $value.address }}": {{ toPrettyJson $value.value | indent 8 | trim }}
     {{- end }}
     }
 }

--- a/charts/rollup/values.yaml
+++ b/charts/rollup/values.yaml
@@ -24,11 +24,12 @@ config:
     # - "FirmOnly" -> blocks are only pulled from DA
     # - "SoftAndFirm" -> blocks are pulled from both the sequencer and DA
     executionCommitLevel: 'SoftAndFirm'
-    # Definitions around who has funding on startup
-    genesisAccounts:
+    # Initial genesis state allocations, can deploy contracts or set account balances
+    genesisAlloc:
       - address: "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"
-        # The balance must be a string due to size
-        balance: "1000000000000000000000000000"
+        value:
+          # The balance must be a string due to size
+          balance: "1000000000000000000000000000"
     optimism:
       # set to true to enable op-stack integration, and setup rest of config
       enabled: false


### PR DESCRIPTION
This enables folks to set their own smart contracts through the alloc instead of only balances.