### PR TITLE
Support large sequencer account balances

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -6,7 +6,7 @@
       {{- if $index }},{{- end }}
       {
         "address": "{{  $value.address }}",
-        "balance": {{ $value.balance | replace "\"" "" }}
+        "balance": {{ toString $value.balance | replace "\"" "" }}
       }
       {{- end }}
     ],

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -1,7 +1,15 @@
 {
   "app_hash": "",
   "app_state": {
-    "accounts": {{ toPrettyJson .Values.config.sequencer.genesisAccounts | indent 4 | trim }},
+    "accounts": [
+      {{- range $index, $value := .Values.config.sequencer.genesisAccounts }}
+      {{- if $index }},{{- end }}
+      {
+        "address": "{{  $value.address }}",
+        "balance": {{ $value.balance | replace "\"" "" }}
+      }
+      {{- end }}
+    ],
     "authority_sudo_key": "{{ .Values.config.sequencer.sudoAuthorityKey }}",
     "native_asset_base_denomination": "nria"
   },

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -12,16 +12,17 @@ config:
   moniker: "node0"
   sequencer:
     sudoAuthorityKey: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
+    # Note balances must be strings support templating with the u128 size account balances
     genesisAccounts:
     - address: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
-      balance: 1000000000000000000
+      balance: "340282366920938463463374607431768211455"
     - address: 34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a
-      balance: 1000000000000000000
+      balance: "340282366920938463463374607431768211455"
     - address: 60709e2d391864b732b4f0f51e387abb76743871
-      balance: 1000000000000000000
+      balance: "340282366920938463463374607431768211455"
       # NOTE - the following address matches the privKey that funds the sequencer-faucet
     - address: 00d75b270542084a54fcf0d0f6eab0402982d156
-      balance: 500000000000000000000
+      balance: "340282366920938463463374607431768211455"
 
   # Values for CometBFT node configuration
   cometBFT:

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -12,7 +12,7 @@ config:
   moniker: "node0"
   sequencer:
     sudoAuthorityKey: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
-    # Note balances must be strings support templating with the u128 size account balances
+    # Note large balances must be strings support templating with the u128 size account balances
     genesisAccounts:
     - address: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
       balance: "340282366920938463463374607431768211455"


### PR DESCRIPTION
Templating w/ go and numbers is weird. We support u128 balances in sequencer, wrapping in string and removing quotes allows these to have a path by which they can work.