### PR TITLE
fix(rollup): allow specfiying full filter directives in logs

### DIFF
--- a/charts/rollup/templates/configmap.yaml
+++ b/charts/rollup/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.config.rollup.name }}-conductor-env
   namespace: {{ .Values.global.namespace }}
 data:
-  ASTRIA_CONDUCTOR_LOG: "astria_conductor={{ .Values.config.logLevel }}"
+  ASTRIA_CONDUCTOR_LOG: "{{ .Values.config.filterDirectives }}"
   {{- if (index .Values "celestia-node").enabled }}
   ASTRIA_CONDUCTOR_CELESTIA_NODE_URL: "{{ include "celestiaNode.service.adresses.rpc" (index .Subcharts "celestia-node") }}"
   TOKEN_SERVER_URL: "{{ include "celestiaNode.service.adresses.token" (index .Subcharts "celestia-node") }}"
@@ -37,7 +37,7 @@ metadata:
   name: {{ .Values.config.rollup.name }}-composer-env
   namespace: {{ .Values.global.namespace }}
 data:
-  ASTRIA_COMPOSER_LOG: "astria_composer={{ .Values.config.logLevel }}"
+  ASTRIA_CONDUCTOR_LOG: "{{ .Values.config.filterDirectives }}"
   ASTRIA_COMPOSER_API_LISTEN_ADDR: "0.0.0.0:0"
   ASTRIA_COMPOSER_SEQUENCER_URL: "{{ .Values.config.sequencer.rpc }}"
   ASTRIA_COMPOSER_ROLLUPS: "{{ .Values.config.rollup.chainId }}::ws://127.0.0.1:{{ .Values.ports.wsRPC }}"

--- a/charts/rollup/values.yaml
+++ b/charts/rollup/values.yaml
@@ -6,9 +6,11 @@ global:
   useTTY: true
 
 config:
-  # The level at which core astria components will log out
-  # Options are: error, warn, info, and debug
-  logLevel: "debug"
+  # The filter directives which core astria components will use to write trace data.
+  # Common options are log levels: error, warn, info, debug, trace
+  # For a full overview of filter capabilities see:
+  # https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/filter/struct.EnvFilter.html#directives
+  filterDirectives: "debug"
 
   rollup:
     # Default name for the rollup chain


### PR DESCRIPTION
This patch removes the pre-set `astria-conductor=` and `astria-composer=` prefixes in the `*-LOG` env vars set for conductor and composer.

The environment variables `ASTRIA_CONDUCTOR_LOG` and `ASTRIA_COMPOSER_LOG` don't merely allow setting log levels but allow much more expressive filtering of targets (like modules), span names, span-fields or values of span-fields.

For example, I used the following filter directives to test changes to conductor:

```
filterDirectives: "[{config}]=info,[{sequencer_block.height=1951}]=info,[{reconstructed_block.height=1951}]=info,[{block.height=1951}]=info"
```