### PR TITLE
add explicit app label for metrics selector

### DIFF
--- a/charts/rollup/Chart.yaml
+++ b/charts/rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.6
+version: 0.8.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rollup/templates/service.yaml
+++ b/charts/rollup/templates/service.yaml
@@ -49,6 +49,8 @@ apiVersion: v1
 metadata:
   name: {{ .Values.config.rollup.name }}-metrics
   namespace: {{ .Values.global.namespace }}
+  labels:
+    app: {{ .Values.config.rollup.name }}-astria-dev-cluster
 spec:
   selector:
     app: {{ .Values.config.rollup.name }}-astria-dev-cluster


### PR DESCRIPTION
Service Monitor is configured to select on match label, but service template did not explicitly set app label in metadata. 

Broken ex below 
```
~ kdsvc my-rollup-metrics
Name:              my-rollup-metrics
Namespace:         my-ns
Labels:            
                   app.kubernetes.io/managed-by=Helm

~ kd servicemonitor
Name:         my-rollup-metrics
Namespace:    my-ns
Labels:       app=my-rollup-astria-dev-cluster
              app.kubernetes.io/managed-by=Helm
              release=kube-prometheus-stack
Annotations:  meta.helm.sh/release-name: my-rollup
              meta.helm.sh/release-namespace: my-ns
API Version:  monitoring.coreos.com/v1
Kind:         ServiceMonitor
Spec:
  Endpoints:
    Path:     /debug/metrics/prometheus
    Port:     geth-metrics
  Job Label:  geth-metrics
  Namespace Selector:
    Match Names:
      my-ns
  Selector:
    Match Labels:
      app:  my-rollup-astria-dev-cluster